### PR TITLE
Add a direct dependency on ansi-colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/architect/plugin-lambda-invoker#readme",
   "dependencies": {
     "@architect/utils": "^3.1.2",
+    "ansi-colors": "^4.1.1",
     "enquirer": "^2.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
It's used directly in src/index.js. Without this, if I used plugin-lambda-invoker in a project that has no other transitive dependencies on ansi-colors, I get:

```
Error: Plugin error:
- Unable to load plugin 'architect/plugin-lambda-invoker': Cannot find module 'ansi-colors'
```

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
