### PR TITLE
chore: add tests, refactor code a bit to make it a tad more testable.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [ 16.x, 18.x, 20.x ]
+        node-version: [ 18.x, 20.x, 22.x ]
         os: [ windows-latest, ubuntu-latest, macOS-latest ]
 
     # Go
@@ -41,7 +41,6 @@ jobs:
       run: npm install
 
     - name: Test
-      if: matrix.node-version > '16.x'
       run: npm test
       env:
         CI: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 scratch/
 node_modules
 .vscode
+.nyc_output
+coverage

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "module": "commonJS",
+    "moduleResolution": "node",
+    "target": "es6"
+  },
+  "include": ["src/**/*"]
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Interactively invoke Lambdas in Architect Sandbox with arbitrary events",
   "main": "src/index.js",
   "scripts": {
-    "test": "npm run lint",
+    "coverage": "nyc --reporter=lcov --reporter=text npm run test:unit",
+    "test": "npm run lint && npm run coverage",
+    "test:unit": "cross-env tape 'test/unit/**/*-test.js' | tap-arc",
     "lint": "eslint . --fix",
     "rc": "npm version prerelease --preid RC"
   },
@@ -31,7 +33,12 @@
   },
   "devDependencies": {
     "@architect/eslint-config": "^3.0.0",
-    "eslint": "^9.2.0"
+    "cross-env": "^7.0.3",
+    "eslint": "^9.2.0",
+    "nyc": "^17.1.0",
+    "proxyquire": "^2.1.3",
+    "tap-arc": "^1.3.2",
+    "tape": "^5.9.0"
   },
   "keywords": [
     "arc",

--- a/src/index.js
+++ b/src/index.js
@@ -1,164 +1,23 @@
-let { join } = require('path')
-let { existsSync, readFileSync } = require('fs')
 let { updater } = require('@architect/utils')
-let { prompt } = require('enquirer')
-let colors = require('ansi-colors')
 let update = updater('Invoker')
-let mock = require('./event-mocks')
-let { marshall } = require('@aws-sdk/util-dynamodb')
+let bindInputHandler = require('./input-handler')
+let { start, end, defaultPragmas } = require('./utils')
 let deactivatedInvoke = async () => console.log('Sandbox not yet started!')
-
-let lastInvoke
 
 let sandbox = {
   start: async ({ inventory: { inv }, invoke }) => {
     start()
+    let pragmas = defaultPragmas.slice(0)
     update.status(`Event invoker started, select an event to invoke by pressing 'i'`)
     plugin.invoke = invoke
-    let { cwd, preferences } = inv._project
-    let jsonMocks = join(cwd, 'sandbox-invoke-mocks.json')
-    let jsMocks = join(cwd, 'sandbox-invoke-mocks.js')
-    let cjsMocks = join(cwd, 'sandbox-invoke-mocks.cjs')
-    let mjsMocks = join(cwd, 'sandbox-invoke-mocks.mjs')
-
-    let pragmas = [ 'customLambdas', 'events', 'queues', 'scheduled', 'tables-streams' ]
+    let { preferences } = inv._project
     let prefs = preferences?.sandbox?.invoker
     if (prefs) {
       if (Array.isArray(prefs)) pragmas = prefs
       else if (typeof prefs === 'string') pragmas = [ prefs ]
       else throw Error('Invalid @architect/plugin-lambda-invoker plugin preferences')
     }
-
-    process.stdin.on('data', async function eventInvokeListener (input) {
-      // Build out the available event list each time to prevent caching
-      let events = {}
-      pragmas.forEach(pragma => {
-        if (inv[pragma]) inv[pragma].forEach(({ name }) => {
-          events[`@${pragma} ${name}`] = { pragma, name }
-        })
-      })
-      // Add a cancel option should one desire
-      events.cancel = ''
-
-      let lastEventName
-      if (lastInvoke) {
-        lastEventName = `Last invoke: @${lastInvoke.pragma} ${lastInvoke.name} (${lastInvoke.mockName})`
-        events[lastEventName] = lastInvoke
-      }
-
-      start()
-      input = String(input)
-      // Reset Enquirer's styles
-      let options = {
-        prefix: colors.white(colors.symbols?.question ?? '?'),
-        styles: {
-          em: colors.cyan, // Clear underlines
-          danger: colors.red,
-          strong: colors.white,
-        },
-      }
-      if (input === 'i') {
-        if (Object.keys(events).length === 1) {
-          let none = 'No Lambdas found to invoke'
-          if (pragmas.length) update.status(none, `Using the following pragmas: @${pragmas.join(', @')}`)
-          else update.status(none)
-          return
-        }
-
-        let userPayload = {}
-        let mockName = 'empty'
-        let pragma, name, mocks, skipSelection
-
-        // Load invocation mocks
-        /**/ if (existsSync(jsonMocks)) {
-          mocks = JSON.parse(readFileSync(jsonMocks))
-        }
-        else if (existsSync(jsMocks)) {
-          mocks = await getMod(jsMocks)
-        }
-        else if (existsSync(cjsMocks)) {
-          // eslint-disable-next-line
-            mocks = require(cjsMocks)
-        }
-        else if (existsSync(mjsMocks)) {
-          mocks = await getMod(mjsMocks)
-        }
-
-        try {
-          let { lambda } = await prompt({
-            type: 'select',
-            name: 'lambda',
-            numbered: true,
-            message: 'Which event do you want to invoke?',
-            hint: '\nYou can use numbers to change your selection',
-            choices: Object.keys(events),
-          }, options)
-          if (lambda === 'cancel') return start()
-          else if (lambda === lastEventName) {
-            skipSelection = true
-            var event = events[lastEventName]
-            mockName = event.mockName
-          }
-          else {
-            var event = events[lambda]
-          }
-          pragma = event.pragma
-          name = event.name
-
-          // Set up non-cached user payload from last event
-          if (lambda === lastEventName) {
-            userPayload = mocks[pragma][name][mockName] || {}
-          }
-        }
-        catch {
-          update.status('Canceled invoke')
-          return start()
-        }
-
-        // Present options for mocks (if any)
-        let mockable = ![ 'scheduled', 'tables-streams' ].includes(pragma)
-        if (mocks?.[pragma]?.[name] && mockable && !skipSelection) {
-          let selection = await prompt({
-            type: 'select',
-            name: 'mock',
-            numbered: true,
-            message: 'Which mock do you want to invoke?',
-            choices: [ ...Object.keys(mocks[pragma][name]), 'empty' ],
-          }, options)
-          mockName = selection.mock
-          userPayload = mocks[pragma][name][mockName] || {}
-        }
-        lastInvoke = { pragma, name, mockName, userPayload }
-
-        let payload
-        /**/ if (pragma === 'events') payload = mock.events(userPayload)
-        else if (pragma === 'queues') payload = mock.queues(userPayload)
-        else if (pragma === 'scheduled') payload = mock.scheduled()
-        else if (pragma === 'customLambdas') payload = mock.customLambdas(userPayload)
-        else if (pragma === 'tables-streams') {
-          let { eventName } = await prompt({
-            type: 'select',
-            name: 'eventName',
-            message: 'Which kind of Dynamo Stream event do you want to invoke?',
-            choices: [ 'INSERT', 'MODIFY', 'REMOVE' ],
-          })
-          payload = mock.tablesStreams(eventName, marshallJson(mocks?.[pragma]?.[name]?.[eventName]))
-        }
-        else {
-          if (!Object.keys(userPayload).length) {
-            update.warning('Warning: real AWS event sources generally do not emit empty payloads')
-          }
-          payload = userPayload
-        }
-
-        // Wrap it up and invoke!
-        let msg = `Invoking @${pragma} ${name}`
-        msg += ` with ${mockName === 'empty' ? 'empty' : `'${mockName}'`} payload`
-        update.status(msg)
-        await invoke({ pragma, name, payload })
-        start()
-      }
-    })
+    process.stdin.on('data', bindInputHandler(update, pragmas, inv, invoke))
   },
   end: async () => {
     // Only remove our listener; removing Enquirer causes funky behavior
@@ -178,60 +37,3 @@ let plugin = {
 }
 module.exports = plugin
 
-// Necessary per Enquirer #326
-function start () {
-  if (process.stdin.isTTY) {
-    process.stdin.setRawMode(true)
-    process.stdin.setEncoding('utf8')
-    process.stdin.resume()
-  }
-}
-
-// Super important to pause stdin, or Sandbox will hang forever in tests
-function end () {
-  if (process.stdin.isTTY) {
-    process.stdin.pause()
-  }
-}
-
-
-let esmErrors = [
-  'Cannot use import statement outside a module',
-  `Unexpected token 'export'`,
-  'require() of ES Module',
-  'Must use import to load ES Module',
-]
-let hasEsmError = err => esmErrors.some(msg => err.message.includes(msg))
-async function getMod (filepath) {
-  let mod
-
-  // Best effort to ensure changes to mocks are always reflected
-  delete require.cache[require.resolve(filepath)]
-
-  try {
-    mod = require(filepath)
-  }
-  catch (err) {
-    if (hasEsmError(err)) {
-      let path = process.platform.startsWith('win')
-        ? 'file://' + filepath
-        : filepath
-      let imported = await import(path)
-      mod = imported.default ? imported.default : imported
-    }
-    else {
-      throw err
-    }
-  }
-
-  return mod
-}
-// Marshalls Json from the mock into keys and newimage for tables-streams
-function marshallJson (json) {
-  const marshalled = marshall(json)
-  const Keys = Object.keys(marshalled).reduce((keys, key) => {
-    keys[key] = { [Object.keys(marshalled[key])[0]]: true }
-    return keys
-  }, {})
-  return { Keys, NewImage: marshalled }
-}

--- a/src/input-handler.js
+++ b/src/input-handler.js
@@ -1,0 +1,188 @@
+let { join } = require('path')
+let { existsSync, readFileSync } = require('fs')
+let { prompt } = require('enquirer')
+let colors = require('ansi-colors')
+let { marshall } = require('@aws-sdk/util-dynamodb')
+let mock = require('./event-mocks')
+let { start } = require('./utils')
+
+let lastInvoke
+
+module.exports = function bindInputHandler (update, pragmas, inv, invoke) {
+  let cwd = inv._project.cwd
+  let jsonMocks = join(cwd, 'sandbox-invoke-mocks.json')
+  let jsMocks = join(cwd, 'sandbox-invoke-mocks.js')
+  let cjsMocks = join(cwd, 'sandbox-invoke-mocks.cjs')
+  let mjsMocks = join(cwd, 'sandbox-invoke-mocks.mjs')
+  return async function eventInvokeListener (input) {
+    // Build out the available event list each time to prevent caching
+    let events = {}
+    pragmas.forEach(pragma => {
+      if (inv[pragma]) inv[pragma].forEach(({ name }) => {
+        events[`@${pragma} ${name}`] = { pragma, name }
+      })
+    })
+    // Add a cancel option should one desire
+    events.cancel = ''
+
+    let lastEventName
+    if (lastInvoke) {
+      lastEventName = `Last invoke: @${lastInvoke.pragma} ${lastInvoke.name} (${lastInvoke.mockName})`
+      events[lastEventName] = lastInvoke
+    }
+
+    start()
+    input = String(input)
+    // Reset Enquirer's styles
+    let options = {
+      prefix: colors.white(colors.symbols?.question ?? '?'),
+      styles: {
+        em: colors.cyan, // Clear underlines
+        danger: colors.red,
+        strong: colors.white,
+      },
+    }
+    if (input === 'i') {
+      if (Object.keys(events).length === 1) {
+        let none = 'No Lambdas found to invoke'
+        if (pragmas.length) update.status(none, `Using the following pragmas: @${pragmas.join(', @')}`)
+        else update.status(none)
+        return
+      }
+
+      let userPayload = {}
+      let mockName = 'empty'
+      let pragma, name, mocks, skipSelection
+
+      // Load invocation mocks
+      if (existsSync(jsonMocks)) {
+        mocks = JSON.parse(readFileSync(jsonMocks))
+      }
+      else if (existsSync(jsMocks)) {
+        mocks = await getMod(jsMocks)
+      }
+      else if (existsSync(cjsMocks)) {
+        mocks = require(cjsMocks)
+      }
+      else if (existsSync(mjsMocks)) {
+        mocks = await getMod(mjsMocks)
+      }
+
+      try {
+        let { lambda } = await prompt({
+          type: 'select',
+          name: 'lambda',
+          numbered: true,
+          message: 'Which event do you want to invoke?',
+          hint: '\nYou can use numbers to change your selection',
+          choices: Object.keys(events),
+        }, options)
+        if (lambda === 'cancel') return start()
+        else if (lambda === lastEventName) {
+          skipSelection = true
+          var event = events[lastEventName]
+          mockName = event.mockName
+        }
+        else {
+          var event = events[lambda]
+        }
+        pragma = event.pragma
+        name = event.name
+
+        // Set up non-cached user payload from last event
+        if (lambda === lastEventName) {
+          userPayload = mocks[pragma][name][mockName] || {}
+        }
+      }
+      catch {
+        update.status('Canceled invoke')
+        return start()
+      }
+
+      // Present options for mocks (if any)
+      let mockable = ![ 'scheduled', 'tables-streams' ].includes(pragma)
+      if (mocks?.[pragma]?.[name] && mockable && !skipSelection) {
+        let selection = await prompt({
+          type: 'select',
+          name: 'mock',
+          numbered: true,
+          message: 'Which mock do you want to invoke?',
+          choices: [ ...Object.keys(mocks[pragma][name]), 'empty' ],
+        }, options)
+        mockName = selection.mock
+        userPayload = mocks[pragma][name][mockName] || {}
+      }
+      lastInvoke = { pragma, name, mockName, userPayload }
+
+      let payload
+      if (pragma === 'events') payload = mock.events(userPayload)
+      else if (pragma === 'queues') payload = mock.queues(userPayload)
+      else if (pragma === 'scheduled') payload = mock.scheduled()
+      else if (pragma === 'customLambdas') payload = mock.customLambdas(userPayload)
+      else if (pragma === 'tables-streams') {
+        let { eventName } = await prompt({
+          type: 'select',
+          name: 'eventName',
+          message: 'Which kind of Dynamo Stream event do you want to invoke?',
+          choices: [ 'INSERT', 'MODIFY', 'REMOVE' ],
+        })
+        payload = mock.tablesStreams(eventName, marshallJson(mocks?.[pragma]?.[name]?.[eventName]))
+      }
+      else {
+        if (!Object.keys(userPayload).length) {
+          update.warning('Warning: real AWS event sources generally do not emit empty payloads')
+        }
+        payload = userPayload
+      }
+
+      // Wrap it up and invoke!
+      let msg = `Invoking @${pragma} ${name}`
+      msg += ` with ${mockName === 'empty' ? 'empty' : `'${mockName}'`} payload`
+      update.status(msg)
+      await invoke({ pragma, name, payload })
+      start()
+    }
+  }
+}
+
+async function getMod (filepath) {
+  let mod
+
+  // Best effort to ensure changes to mocks are always reflected
+  delete require.cache[require.resolve(filepath)]
+
+  try {
+    mod = require(filepath)
+  }
+  catch (err) {
+    if (hasEsmError(err)) {
+      let path = process.platform.startsWith('win')
+        ? 'file://' + filepath
+        : filepath
+      let imported = await import(path)
+      mod = imported.default ? imported.default : imported
+    }
+    else {
+      throw err
+    }
+  }
+
+  return mod
+}
+
+let esmErrors = [
+  'Cannot use import statement outside a module',
+  `Unexpected token 'export'`,
+  'require() of ES Module',
+  'Must use import to load ES Module',
+]
+let hasEsmError = err => esmErrors.some(msg => err.message.includes(msg))
+// Marshalls Json from the mock into keys and newimage for tables-streams
+function marshallJson (json) {
+  const marshalled = marshall(json)
+  const Keys = Object.keys(marshalled).reduce((keys, key) => {
+    keys[key] = { [Object.keys(marshalled[key])[0]]: true }
+    return keys
+  }, {})
+  return { Keys, NewImage: marshalled }
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,17 @@
+module.exports = {
+  // Necessary per Enquirer #326
+  start: function start () {
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(true)
+      process.stdin.setEncoding('utf8')
+      process.stdin.resume()
+    }
+  },
+  // Super important to pause stdin, or Sandbox will hang forever in tests
+  end: function end () {
+    if (process.stdin.isTTY) {
+      process.stdin.pause()
+    }
+  },
+  defaultPragmas: [ 'customLambdas', 'events', 'queues', 'scheduled', 'tables-streams' ],
+}

--- a/test/unit/input-handler-test.js
+++ b/test/unit/input-handler-test.js
@@ -1,0 +1,83 @@
+let test = require('tape')
+let { defaultPragmas } = require('../../src/utils')
+let pragmas = defaultPragmas.slice(0)
+let proxyquire = require('proxyquire')
+
+// Set up mocks for dependencies
+function createFSMock () {
+  return {
+    readFileSync: () => (JSON.stringify({})),
+    existsSync: () => true,
+  }
+}
+function createInvMock () {
+  return { inv: { _project: { cwd: process.cwd(), preferences: {} } } }
+}
+function createLogMock () {
+  return { status: () => ({}) }
+}
+function createEnquirerMock () {
+  return { prompt: async () => ({}) }
+}
+let invoke = async () => ({})
+function createMocks () {
+  return {
+    fsMock: createFSMock(),
+    invoke,
+    invMock: createInvMock(),
+    logger: createLogMock(),
+    enquirer: createEnquirerMock(),
+  }
+}
+
+function mockHandlerFactory (mox) {
+  delete process.env.ARC_ENV
+  return proxyquire('../../src/input-handler', {
+    fs: mox.fsMock,
+    enquirer: mox.enquirer,
+    './utils': { start: () => ({}) },
+  })
+}
+
+test('Should do nothing if handler not invoked with `i`', async t => {
+  let mocks = createMocks()
+  const intercept = t.capture(mocks, 'invoke')
+  let handler = mockHandlerFactory(mocks)(mocks.logger, pragmas, mocks.invMock.inv, mocks.invoke)
+  await handler('x')
+  const invoked = intercept()
+  t.equal(invoked.length, 0, 'lambda invoke not called')
+})
+
+test('Should return if no lambdas to invoke', async t => {
+  let mocks = createMocks()
+  const intercept = t.capture(mocks, 'invoke')
+  const logcept = t.capture(mocks.logger, 'status')
+  let handler = mockHandlerFactory(mocks)(mocks.logger, pragmas, mocks.invMock.inv, mocks.invoke)
+  await handler('i')
+  const invoked = intercept()
+  const logged = logcept()
+  t.equal(invoked.length, 0, 'lambda invoke not called')
+  t.match(logged[0].args[0], /no lambdas found/i, 'logged that no lambdas found')
+})
+
+test('Should prompt for lambda selection and allow for cancellation', async t => {
+  let mocks = createMocks()
+  const intercept = t.capture(mocks, 'invoke')
+  t.capture(mocks.enquirer, 'prompt', async () => ({ lambda: 'cancel' }))
+  mocks.invMock.inv['events'] = [ { name: 'test-event' } ]
+  let handler = mockHandlerFactory(mocks)(mocks.logger, pragmas, mocks.invMock.inv, mocks.invoke)
+  await handler('i')
+  const invoked = intercept()
+  t.equal(invoked.length, 0, 'lambda invoke not called')
+})
+
+test('Should prompt for lambda selection and invoke matching lambda', async t => {
+  let mocks = createMocks()
+  const intercept = t.capture(mocks, 'invoke')
+  t.capture(mocks.enquirer, 'prompt', async () => ({ lambda: '@events test-event' }))
+  mocks.invMock.inv['events'] = [ { name: 'test-event' } ]
+  let handler = mockHandlerFactory(mocks)(mocks.logger, pragmas, mocks.invMock.inv, mocks.invoke)
+  await handler('i')
+  const invoked = intercept()
+  t.equal(invoked.length, 1, 'lambda invoke called')
+})


### PR DESCRIPTION
- test against node 18, 20 and 22 in CI
- add a `jsconfig.json` to get some LSP action
- first cut at unit tests and code coverage
- mainly moves the event handler code from `index.js` to `input-handler.js`