### PR TITLE
fix for MJS import issue in Node 20.19+

### DIFF
--- a/src/input-handler.js
+++ b/src/input-handler.js
@@ -158,6 +158,9 @@ async function getMod (filepath) {
 
   try {
     mod = require(filepath)
+    if (process?.features?.require_module === true && mod.default) {
+      mod = mod.default
+    }
   }
   catch (err) {
     if (hasEsmError(err)) {


### PR DESCRIPTION
This fix addresses an issue with importing mocks in an MJS file after the Node 20.19 back port of require(esm).

Uses the [process.features.require_module](https://nodejs.org/api/process.html#processfeaturesrequire_module) flag to work out what should be happening.

As there were no existing tests to validate the mock import behaviour, I was unsure how to create a test for this.